### PR TITLE
add new feature "hidesExplorerArrows" of vscode 1.8

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -81,7 +81,8 @@ const operations = {
             'rootFolderExpanded',
             'folder',
             'folderExpanded',
-            'file'
+            'file',
+            'hidesExplorerArrows'
         ];
 
         delete light.iconDefinitions;

--- a/icons.json
+++ b/icons.json
@@ -4,6 +4,7 @@
     "folder": "folder",
     "folderExpanded": "folder.expanded",
     "file": "file",
+    "hidesExplorerArrows":true,
     "folderNames": {
         ".dub": "folder-d",
         ".git": "folder-git",


### PR DESCRIPTION
Hi Laurent,

this PR adds a new feature of VSCode to your fantastic icon set. VSCode is able to hide the rotating triangle in front of folders since the latest version 1.8. The entry of the changelog can be found [here](https://code.visualstudio.com/updates/v1_18#_folder-icons-in-file-icon-themes).

Cheers,
Thomas