### PR TITLE
Include ".tsv" as CSV file type

### DIFF
--- a/icons.json
+++ b/icons.json
@@ -370,6 +370,7 @@
         "tiff": "image",
         "tmLanguage": "file-xml",
         "toml": "file-toml",
+        "tsv": "file-csv",
         "twig": "twig",
         "txt": "file-text",
         "vagrantfile": "vagrant",


### PR DESCRIPTION
Some systems prefer ".tsv" when the tabs are the delimiter, but these are otherwise treated like CSV files.