### PR TITLE
A simpler SVG icon

### DIFF
--- a/source/minimalistic-icons/svg.svg
+++ b/source/minimalistic-icons/svg.svg
@@ -1,30 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="320" height="320" version="1.1">
-    <defs>
-        <rect id="branch-background" width="60" height="120" x="130" y="60" fill="#000000"/>
-        <g id="branch" fill="#000000">
-            <circle cx="160" cy="60" r="30"/>
-            <rect width="20" height="120" x="150" y="60"/>
-        </g>
-        <mask id="mask-branches">
-            <rect width="320" height="320" fill="#fff"/>
-            <use transform="rotate(-90 160 160)" xlink:href="#branch"/>
-            <use transform="rotate(-45 160 160)" xlink:href="#branch"/>
-            <use transform="rotate(0 160 160)" xlink:href="#branch"/>
-            <use transform="rotate(45 160 160)" xlink:href="#branch"/>
-            <use transform="rotate(90 160 160)" xlink:href="#branch"/>
-        </mask>
-        <mask id="mask-text">
-            <rect width="320" height="320" fill="#fff"/>
-            <g fill="none" stroke="#000" stroke-linejoin="round" stroke-width="20">
-                <polyline points="100,190 50,190 50,230 90,230 90,270 40,270"/>
-                <polyline points="130,180 130,250 150,270 170,250 170,180"/>
-                <polyline points="280,190 230,190 210,210 210,250 230,270 270,270 270,230 240,230"/>
-            </g>
-        </mask>
-    </defs>
-    <g mask="url(#mask-text)">
-        <rect width="320" height="320" fill="#bfbfbf" mask="url(#mask-branches)" rx="20" ry="20"/>
-        <rect width="280" height="140" x="20" y="160" fill="#bfbfbf" rx="20" ry="20"/>
+    <g>
+        <path id="svgbar" fill="#bfbfbf" d="M50,145.8513 a27.4171,27.4171 0 1 0 0,31.7026 h220 a27.4171,27.4171 0 1 0 0,-31.7026 Z"/>
+        <use xlink:href="#svgbar" transform="rotate(45)" transform-origin="center"/>
+        <use xlink:href="#svgbar" transform="rotate(90)" transform-origin="center"/>
+        <use xlink:href="#svgbar" transform="rotate(135)" transform-origin="center"/>
     </g>
 </svg>

--- a/source/simple-icons/svg.svg
+++ b/source/simple-icons/svg.svg
@@ -1,45 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="320" height="320" version="1.1">
-    <defs>
-        <rect id="branch-background" width="60" height="120" x="130" y="60" fill="#000000"/>
-        <g id="branch" fill="#ffffff">
-            <circle cx="160" cy="60" r="30" stroke="#000000" stroke-width="20"/>
-            <rect width="20" height="120" x="150" y="60"/>
-        </g>
-    </defs>
-    <rect width="200" height="200" x="0" y="0" fill="#ffb13b" rx="20" ry="20"/>
-    <rect width="200" height="200" x="120" y="120" fill="#de8500" rx="20" ry="20"/>
-    <g fill="#ff9900">
-        <rect width="160" height="160" x="160" y="0" rx="20" ry="20"/>
-        <rect width="160" height="160" x="0" y="160" rx="20" ry="20"/>
-        <circle cx="60" cy="160" r="60"/>
-        <circle cx="90" cy="90" r="60"/>
-        <circle cx="160" cy="60" r="60"/>
-        <circle cx="230" cy="90" r="60"/>
-        <circle cx="260" cy="160" r="60"/>
-        <circle cx="160" cy="260" r="60"/>
-    </g>
-    <g fill="#000000">
-        <circle cx="60" cy="160" r="40"/>
-        <circle cx="90" cy="90" r="40"/>
-        <circle cx="160" cy="60" r="40"/>
-        <circle cx="230" cy="90" r="40"/>
-        <circle cx="260" cy="160" r="40"/>
-    </g>
-    <use transform="rotate(-90 160 160)" xlink:href="#branch-background"/>
-    <use transform="rotate(-45 160 160)" xlink:href="#branch-background"/>
-    <use transform="rotate(0 160 160)" xlink:href="#branch-background"/>
-    <use transform="rotate(45 160 160)" xlink:href="#branch-background"/>
-    <use transform="rotate(90 160 160)" xlink:href="#branch-background"/>
-    <use transform="rotate(-90 160 160)" xlink:href="#branch"/>
-    <use transform="rotate(-45 160 160)" xlink:href="#branch"/>
-    <use transform="rotate(0 160 160)" xlink:href="#branch"/>
-    <use transform="rotate(45 160 160)" xlink:href="#branch"/>
-    <use transform="rotate(90 160 160)" xlink:href="#branch"/>
-    <rect width="280" height="140" x="20" y="160" fill="#000000" rx="20" ry="20"/>
-    <g fill="none" stroke="#ffffff" stroke-linejoin="round" stroke-width="20">
-        <polyline points="100,190 50,190 50,230 90,230 90,270 40,270"/>
-        <polyline points="130,180 130,250 150,270 170,250 170,180"/>
-        <polyline points="280,190 230,190 210,210 210,250 230,270 270,270 270,230 240,230"/>
+    <g>
+        <path id="svgbar" fill="#ff9900" d="M50,145.8513 a27.4171,27.4171 0 1 0 0,31.7026 h220 a27.4171,27.4171 0 1 0 0,-31.7026 Z"/>
+        <use xlink:href="#svgbar" transform="rotate(45)" transform-origin="center"/>
+        <use xlink:href="#svgbar" transform="rotate(90)" transform-origin="center"/>
+        <use xlink:href="#svgbar" transform="rotate(135)" transform-origin="center"/>
     </g>
 </svg>


### PR DESCRIPTION
Hi 👋 

Thanks for your work on these icons!

I figured I would suggest this change, since I found the SVG icon is very complex compared to other icons in the set.

The new icon is based on the [W3C guidelines](https://www.w3.org/2009/08/svg-logos.html) regarding the SVG logo. I tweaked it a little to make it even simpler in both shape & markup, and then changed the fill color grade to match the main one used in the current icon (I thought it fits better in both light and dark themes).

That's all. Thanks!
